### PR TITLE
Typo- changed javac to java

### DIFF
--- a/packages1.md
+++ b/packages1.md
@@ -275,7 +275,7 @@ Let's try it by placing the `HelloWorld` class into the `cs1302.hello` package!
    ```
  
 
-6. Run the program using `javac` with the classpath using `-cp` and include the
+6. Run the program using `java` with the classpath using `-cp` and include the
    fully qualified name (explained below) of the class containing the `main` method:
    
    ```


### PR DESCRIPTION
instructions asked the student to run the program with "javac" instead of "java". The command line text reflected the proper command.